### PR TITLE
docs(scrap): 2026년 3월 스크랩 업데이트

### DIFF
--- a/contents/blog/2026/3/3월 스크랩.md
+++ b/contents/blog/2026/3/3월 스크랩.md
@@ -12,3 +12,9 @@ summary: '-'
 <br/>
 
 [Test IDs are an a11y smell](https://tkdodo.eu/blog/test-ids-are-an-a11y-smell)
+
+<br/>
+
+### 2026-03-27
+
+[Harness design for long-running application development](https://www.anthropic.com/engineering/harness-design-long-running-apps)

--- a/contents/blog/2026/3/3월 스크랩.md
+++ b/contents/blog/2026/3/3월 스크랩.md
@@ -1,0 +1,14 @@
+---
+date: '2026-03-25'
+title: '2026-3 스크랩'
+categories: ['스크랩']
+summary: '-'
+---
+
+### 2026-03-25
+
+[Tooltip components should not exist](https://tkdodo.eu/blog/tooltip-components-should-not-exist)
+
+<br/>
+
+[Test IDs are an a11y smell](https://tkdodo.eu/blog/test-ids-are-an-a11y-smell)

--- a/contents/blog/2026/3/3월 스크랩.md
+++ b/contents/blog/2026/3/3월 스크랩.md
@@ -18,3 +18,9 @@ summary: '-'
 ### 2026-03-27
 
 [Harness design for long-running application development](https://www.anthropic.com/engineering/harness-design-long-running-apps)
+
+<br/>
+
+### 2026-03-30
+
+[시니어 개발자가 AI와 6개월간 25만 라인의 시스템을 만들며 발견한 것들](https://medium.com/@ibare/%EC%8B%9C%EB%8B%88%EC%96%B4-%EA%B0%9C%EB%B0%9C%EC%9E%90%EA%B0%80-ai%EC%99%80-6%EA%B0%9C%EC%9B%94%EA%B0%84-25%EB%A7%8C-%EB%9D%BC%EC%9D%B8%EC%9D%98-%EC%8B%9C%EC%8A%A4%ED%85%9C%EC%9D%84-%EB%A7%8C%EB%93%A4%EB%A9%B0-%EB%B0%9C%EA%B2%AC%ED%95%9C-%EA%B2%83%EB%93%A4-e3935857f35c)

--- a/contents/blog/2026/3/3월 스크랩.md
+++ b/contents/blog/2026/3/3월 스크랩.md
@@ -1,5 +1,5 @@
 ---
-date: '2026-03-25'
+date: '2026-03-31'
 title: '2026-3 스크랩'
 categories: ['스크랩']
 summary: '-'


### PR DESCRIPTION
## 요약
- 2026년 3월 스크랩 문서에 링크 4건 추가
  - TkDodo 글 2건
  - Anthropic harness 관련 글 1건
  - Medium AI system 글 1건

## 변경 파일
- contents/blog/2026/3/3월 스크랩.md

## 비고
- 기존 테스트용 임시 커밋()은 제외하고 스크랩 변경만 분리했습니다.