### PR TITLE
docs(scrap): add May 2026 scrap links

### DIFF
--- a/contents/blog/2026/5/5월 스크랩.md
+++ b/contents/blog/2026/5/5월 스크랩.md
@@ -10,3 +10,19 @@ summary: '-'
 [[번역] startTransition은 언제 정말로 필요할까요?](https://imnotadevleoper.tistory.com/383)
 
 - `startTransition`과 debounce의 차이를 설명해둔 글
+
+<br/>
+
+### 2026-05-14
+
+[프롬프트 한 줄로 화면이 나오는 시대, ‘당근스러운 화면’을 만드는 법](https://medium.com/daangn/%ED%94%84%EB%A1%AC%ED%94%84%ED%8A%B8-%ED%95%9C-%EC%A4%84%EB%A1%9C-%ED%99%94%EB%A9%B4%EC%9D%B4-%EB%82%98%EC%98%A4%EB%8A%94-%EC%8B%9C%EB%8C%80-%EB%8B%B9%EA%B7%BC%EC%8A%A4%EB%9F%AC%EC%9A%B4-%ED%99%94%EB%A9%B4%EC%9D%84-%EB%A7%8C%EB%93%9C%EB%8A%94-%EB%B2%95-0bc268f819c7)
+
+- 바이브 코딩 도구의 한계를 넘기 위해, 당근이 디자인 시스템 의사결정을 `어드민 → CLI → 에이전트`로 자동화해간 과정을 정리한 글
+
+<br/>
+
+### 2026-05-24
+
+[1인 빌더의 지난 1년 회고](https://www.integer.blog/posteady-1st-anniversary/?ref=hanjeongsu-beulrogeu-newsletter)
+
+- Posteady 1주년 회고. 실제 고객과 타깃 고객이 어긋났던 점, 비타민형 기능에 치우친 점, 유료화·SEO·마케팅 계정 분리를 늦춘 실수를 돌아보며 결국 “진짜 고통을 푸는 기능”과 꾸준함이 중요하다는 내용을 담은 글

--- a/contents/blog/2026/5/5월 스크랩.md
+++ b/contents/blog/2026/5/5월 스크랩.md
@@ -1,0 +1,12 @@
+---
+date: '2026-05-31'
+title: '2026-5 스크랩'
+categories: ['스크랩']
+summary: '-'
+---
+
+### 2026-05-12
+
+[[번역] startTransition은 언제 정말로 필요할까요?](https://imnotadevleoper.tistory.com/383)
+
+- `startTransition`과 debounce의 차이를 설명해둔 글


### PR DESCRIPTION
## Summary
- 2026년 5월 스크랩 글에 당근 디자인 시스템/에이전트 글 추가
- 1인 빌더 Posteady 1주년 회고 글 추가
- 기존 스크랩 글 스타일을 참고해 항목 사이에 `<br/>` 구분 유지

## Test Plan
- [x] `yarn build`