### PR TITLE
docs: 2026년 6월 스크랩 추가

### DIFF
--- a/contents/blog/2026/6/6월 스크랩.md
+++ b/contents/blog/2026/6/6월 스크랩.md
@@ -1,0 +1,10 @@
+---
+date: '2026-06-01'
+title: '2026-6 스크랩'
+categories: ['스크랩']
+summary: '-'
+---
+
+### 2026-06-01
+
+[장인은 도구를 탓하지 않는다. 도구를 만든다.](https://jonghakseo.github.io/posts/craftsman-makes-tools/)


### PR DESCRIPTION
## 요약
- 2026년 6월 스크랩 파일을 추가했습니다.
- `장인은 도구를 탓하지 않는다. 도구를 만든다.` 링크를 추가했습니다.

## 변경 파일
- `contents/blog/2026/6/6월 스크랩.md`

## 검증
- 링크 제목을 원문 페이지에서 확인했습니다.
- 변경 diff와 커밋/푸시 상태를 확인했습니다.
