### PR TITLE
docs(scrap): 2026년 6월 스크랩 추가

### DIFF
--- a/contents/blog/2026/6/6월 스크랩.md
+++ b/contents/blog/2026/6/6월 스크랩.md
@@ -24,3 +24,11 @@ summary: '-'
 [7년차 개발자의 퇴사 회고](https://all-dev-kang.tistory.com/entry/7%EB%85%84%EC%B0%A8-%EA%B0%9C%EB%B0%9C%EC%9E%90%EC%9D%98-%ED%87%B4%EC%82%AC-%ED%9A%8C%EA%B3%A0)
 
 - 가우디오랩 퇴사와 쿠팡플레이 이직 배경을 중심으로, 네카라쿠배급 조직에 대한 갈증, 영어 기반 글로벌 조직 적응, 풀재택 온보딩과 막내 포지션에서 다시 배우는 감각까지 7년차 프론트엔드 개발자의 커리어 전환 심리를 길게 풀어낸 회고
+
+<br/>
+
+### 2026-06-08
+
+[TanStack Table V9: Taking Form](https://tanstack.com/blog/tanstack-table-v9-taking-form)
+
+- TanStack Table v9의 방향을 직접 설명한 글로, TanStack Store 기반 selector 구독, 큰 virtualized table의 메모리 절감, `createTableHook`을 통한 재사용 가능한 테이블 조합, devtools 정식 통합까지 핵심 변화와 배경을 한 번에 정리했다

--- a/contents/blog/2026/6/6월 스크랩.md
+++ b/contents/blog/2026/6/6월 스크랩.md
@@ -32,3 +32,11 @@ summary: '-'
 [TanStack Table V9: Taking Form](https://tanstack.com/blog/tanstack-table-v9-taking-form)
 
 - TanStack Table v9의 방향을 직접 설명한 글로, TanStack Store 기반 selector 구독, 큰 virtualized table의 메모리 절감, `createTableHook`을 통한 재사용 가능한 테이블 조합, devtools 정식 통합까지 핵심 변화와 배경을 한 번에 정리했다
+
+<br/>
+
+### 2026-06-18
+
+[리더가 정말 신경 써야 할 것은 생산성이 아니다 - 취향은 고장 속에서만 자란다](https://evan-moon.github.io/2026/06/12/illusion-of-ai-mastery/#%EC%B7%A8%ED%96%A5%EC%9D%80-%EA%B3%A0%EC%9E%A5-%EC%86%8D%EC%97%90%EC%84%9C%EB%A7%8C-%EC%9E%90%EB%9E%80%EB%8B%A4)
+
+- AI 시대의 개발 리더십에서 생산성보다 실패·고장·토론을 통해 팀의 취향과 판단 기준을 기르는 일이 중요하다는 관점을 다룬 섹션

--- a/contents/blog/2026/6/6월 스크랩.md
+++ b/contents/blog/2026/6/6월 스크랩.md
@@ -40,3 +40,11 @@ summary: '-'
 [리더가 정말 신경 써야 할 것은 생산성이 아니다 - 취향은 고장 속에서만 자란다](https://evan-moon.github.io/2026/06/12/illusion-of-ai-mastery/#%EC%B7%A8%ED%96%A5%EC%9D%80-%EA%B3%A0%EC%9E%A5-%EC%86%8D%EC%97%90%EC%84%9C%EB%A7%8C-%EC%9E%90%EB%9E%80%EB%8B%A4)
 
 - AI 시대의 개발 리더십에서 생산성보다 실패·고장·토론을 통해 팀의 취향과 판단 기준을 기르는 일이 중요하다는 관점을 다룬 섹션
+
+<br/>
+
+### 2026-06-22
+
+[How an Underrated Refactor Saved 90% Memory Usage](https://tanstack.com/blog/tanstack-table-v9-memory-performance)
+
+- TanStack Table v9에서 row·column·cell·header API를 각 객체 인스턴스가 아니라 공유 prototype에 올려, 대규모 테이블의 메모리 사용량을 v8 대비 최대 약 90% 줄인 리팩터링 과정을 설명한 글

--- a/contents/blog/2026/6/6월 스크랩.md
+++ b/contents/blog/2026/6/6월 스크랩.md
@@ -16,3 +16,11 @@ summary: '-'
 [The Conductor Rewrite](https://performance.dev/the-conductor-rewrite)
 
 - Tauri 기반 데스크톱 앱에서 React DevTools를 직접 쓰기 어려운 제약, idle agent process 정리와 `--resume <uuid>` 기반 세션 복구, 첫 토큰 이전의 Git checkpoint를 백그라운드로 빼 체감 지연을 줄인 과정까지 Conductor의 성능 개선 포인트를 정리한 글
+
+<br/>
+
+### 2026-06-06
+
+[7년차 개발자의 퇴사 회고](https://all-dev-kang.tistory.com/entry/7%EB%85%84%EC%B0%A8-%EA%B0%9C%EB%B0%9C%EC%9E%90%EC%9D%98-%ED%87%B4%EC%82%AC-%ED%9A%8C%EA%B3%A0)
+
+- 가우디오랩 퇴사와 쿠팡플레이 이직 배경을 중심으로, 네카라쿠배급 조직에 대한 갈증, 영어 기반 글로벌 조직 적응, 풀재택 온보딩과 막내 포지션에서 다시 배우는 감각까지 7년차 프론트엔드 개발자의 커리어 전환 심리를 길게 풀어낸 회고

--- a/contents/blog/2026/6/6월 스크랩.md
+++ b/contents/blog/2026/6/6월 스크랩.md
@@ -1,0 +1,18 @@
+---
+date: '2026-06-30'
+title: '2026-6 스크랩'
+categories: ['스크랩']
+summary: '-'
+---
+
+### 2026-06-01
+
+[장인은 도구를 탓하지 않는다. 도구를 만든다.](https://jonghakseo.github.io/posts/craftsman-makes-tools/)
+
+<br/>
+
+### 2026-06-04
+
+[The Conductor Rewrite](https://performance.dev/the-conductor-rewrite)
+
+- Tauri 기반 데스크톱 앱에서 React DevTools를 직접 쓰기 어려운 제약, idle agent process 정리와 `--resume <uuid>` 기반 세션 복구, 첫 토큰 이전의 Git checkpoint를 백그라운드로 빼 체감 지연을 줄인 과정까지 Conductor의 성능 개선 포인트를 정리한 글

--- a/contents/blog/2026/6/6월 스크랩.md
+++ b/contents/blog/2026/6/6월 스크랩.md
@@ -48,3 +48,9 @@ summary: '-'
 [How an Underrated Refactor Saved 90% Memory Usage](https://tanstack.com/blog/tanstack-table-v9-memory-performance)
 
 - TanStack Table v9에서 row·column·cell·header API를 각 객체 인스턴스가 아니라 공유 prototype에 올려, 대규모 테이블의 메모리 사용량을 v8 대비 최대 약 90% 줄인 리팩터링 과정을 설명한 글
+
+<br/>
+
+### 2026-06-24
+
+[Less is more, more or less](https://jakub.kr/writing/less-is-more)


### PR DESCRIPTION
## 요약
- 2026년 6월 스크랩 문서를 추가했습니다.
- 6월 중 수집한 개발/커리어/AI/성능 관련 링크와 짧은 메모를 정리했습니다.

## 검증
- `git diff --check origin/main...HEAD`
- 변경 범위: Markdown 스크랩 문서 1개