### PR TITLE
2026년 7월 스크랩 추가

### DIFF
--- a/contents/blog/2026/7/7월 스크랩.md
+++ b/contents/blog/2026/7/7월 스크랩.md
@@ -1,0 +1,10 @@
+---
+date: '2026-07-31'
+title: '2026-7 스크랩'
+categories: ['스크랩']
+summary: '-'
+---
+
+### 2026-07-10
+
+[Reverse Engineering ChatGPT Web: How OpenAI Built for a Billion Users](https://performance.dev/chatgpt)

--- a/contents/blog/2026/7/7월 스크랩.md
+++ b/contents/blog/2026/7/7월 스크랩.md
@@ -8,3 +8,11 @@ summary: '-'
 ### 2026-07-10
 
 [Reverse Engineering ChatGPT Web: How OpenAI Built for a Billion Users](https://performance.dev/chatgpt)
+
+<br/>
+
+### 2026-07-14
+
+[브라우저의 메인 스레드는 비싸다](https://kciter.so/posts/the-expensive-main-thread/)
+
+- 프론트엔드 버벅임의 핵심을 “코드가 느리냐”보다 “메인 스레드를 얼마나 오래 붙잡느냐”로 설명하며, 실시간 UI에서 긴 작업 쪼개기·잦은 작업 묶기·입력 우선 처리·덜 급한 작업 미루기·워커 활용·오래된 작업 버리기 같은 메인 스레드 예산 관리 원칙을 정리한 글


### PR DESCRIPTION
## 요약
- 2026-07-14 스크랩에 kciter.so의 ‘브라우저의 메인 스레드는 비싸다’ 링크와 요약을 추가했습니다.

## 검증
- git diff --check 통과