### PR TITLE
7월 스크랩: Parse, Don't Validate 추가

### DIFF
--- a/contents/blog/2026/7/7월 스크랩.md
+++ b/contents/blog/2026/7/7월 스크랩.md
@@ -40,3 +40,11 @@ summary: '-'
 [코드를 읽거나 설명할 줄 몰라도, 스펙을 만족하고 버그를 고칠 수 있다면 상관없을까](https://yceffort.kr/2026/06/do-you-need-to-read-code)
 
 - AI가 코드 작성을 크게 대신하는 시대에도 “스펙 충족·버그 수정”을 누가 어떻게 검증하고 책임질 수 있는지를 묻는 글. 코드 읽기가 목적 그 자체는 아니지만, 테스트가 놓치는 스펙 공백·숨겨진 커플링·탐지 문제를 다루려면 구현 이해가 여전히 필요하다는 관점으로 정리한다.
+
+<br/>
+
+### 2026-07-19
+
+[Parse, Don't Validate — In a Language That Doesn't Want You To](https://cekrem.github.io/posts/parse-dont-validate-typescript/)
+
+- TypeScript에서 단순 validator가 검증 결과를 타입에 남기지 못해 재검증과 방어 코드를 낳는 문제를 짚고, branded type·smart constructor·Result/union 반환을 활용해 “검증된 값”을 더 정밀한 도메인 타입으로 파싱하는 방식을 설명한 글


### PR DESCRIPTION
## 요약
- 2026년 7월 스크랩에 Parse, Don't Validate TypeScript 글을 추가했습니다.
- TypeScript validator 대신 parser/도메인 타입 관점 요약을 함께 적었습니다.

## 검증
- git diff --check 통과